### PR TITLE
array_split is replace with unpack to split string to bytes

### DIFF
--- a/src/Service/Encoder.php
+++ b/src/Service/Encoder.php
@@ -18,10 +18,10 @@ class Encoder
             $frameHead[1] = $masked ? 0x80 | $payloadLength : $payloadLength;
         } elseif ($payloadLength >= 126 && $payloadLength <= 65535) {
             $frameHead[1] = $masked ? 0xFE : 126;
-            $frameHead = array_merge($frameHead, str_split(pack('n', $payloadLength)));
+            $frameHead = array_merge($frameHead, unpack("C*", pack('n', $payloadLength)));
         } else {
             $frameHead[1] = $masked ? 0xFF : 127;
-            $frameHead = array_merge($frameHead, str_split(pack('J', $payloadLength)));
+            $frameHead = array_merge($frameHead, unpack("C*", pack('J', $payloadLength)));
         }
 
         foreach ($frameHead as &$val) {


### PR DESCRIPTION
**Problem:**
When we try to send a message longer than 125 bytes we have an error:

`chr(): Argument #1 ($codepoint) must be of type int, string given `

**Platform:**
PHP 8.3, Alpine Linux in docker on Mac (M1)

**Solution:**
I've replaced `str_split` with `unpack` to split a string to byte array. The solution is tested with different payloads < 65535 bytes but I guess for 3rd case it should also work. 